### PR TITLE
Remove broken gemnasium badge/image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Namespacing [![Build Status](https://travis-ci.org/jah2488/namespacing.png?branch=master)](https://travis-ci.org/jah2488/namespacing) [![Code Climate](https://codeclimate.com/github/jah2488/namespacing.png)](https://codeclimate.com/github/jah2488/namespacing) [![Dependency Status](https://gemnasium.com/jah2488/namespacing.png)](https://gemnasium.com/jah2488/namespacing)
+# Namespacing [![Build Status](https://travis-ci.org/jah2488/namespacing.png?branch=master)](https://travis-ci.org/jah2488/namespacing) [![Code Climate](https://codeclimate.com/github/jah2488/namespacing.png)](https://codeclimate.com/github/jah2488/namespacing)
 [![Gem Version](https://badge.fury.io/rb/namespacing.png)](http://badge.fury.io/rb/namespacing)
 
 


### PR DESCRIPTION
Gemnasium was acquired in 2018 per:
https://about.gitlab.com/press/releases/2018-01-30-gemnasium-acquisition.html